### PR TITLE
Request Signing Returns an Either

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist-newstyle/
 /.stack-work/
+tags


### PR DESCRIPTION
- Allows for better errors rather than silently not including parts of the signature.

- Update `hmacAuth` haddock to explain intended use case.