### PR TITLE
Use crypton instead of deprecated cryptonite

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,7 @@ dependencies:
   - base64-bytestring ^>=1.2
   - bytestring >=0.10 && <0.12
   - case-insensitive ^>=1.2
-  - cryptonite ^>=0.30
+  - crypton ^>=0.32
   - http-api-data >=0.4 && <0.6
   - http-types ^>=0.12
   - http-client ^>=0.7

--- a/wai-middleware-hmac-auth.cabal
+++ b/wai-middleware-hmac-auth.cabal
@@ -23,7 +23,7 @@ library
     , base64-bytestring ==1.2.*
     , bytestring >=0.10 && <0.12
     , case-insensitive ==1.2.*
-    , cryptonite ==0.30.*
+    , crypton ==0.32.*
     , http-api-data >=0.4 && <0.6
     , http-client ==0.7.*
     , http-types ==0.12.*


### PR DESCRIPTION
`cryptonite` is deprecated, so we should use `crypton` instead.